### PR TITLE
Fix crash when Fertilized Dirt or Sand are above each other in world.

### DIFF
--- a/src/main/java/wraith/croptosis/block/FertilizedDirtBlock.java
+++ b/src/main/java/wraith/croptosis/block/FertilizedDirtBlock.java
@@ -1,7 +1,6 @@
 package wraith.croptosis.block;
 
-import net.minecraft.block.Block;
-import net.minecraft.block.BlockState;
+import net.minecraft.block.*;
 import net.minecraft.server.world.ServerWorld;
 import net.minecraft.state.StateManager;
 import net.minecraft.state.property.IntProperty;
@@ -35,12 +34,24 @@ public class FertilizedDirtBlock extends Block {
         super.randomTick(state, world, pos, random);
 
         for (int height = 1; height <= state.get(FertilizedDirtBlock.MAX_HEIGHT); height++) {
-            BlockState topBlockState = world.getBlockState(pos.up(height));
-            Block topBlock = topBlockState.getBlock();
-            if (!(topBlock == BlockRegistry.BLOCKS.get("fertilized_dirt") || topBlock == BlockRegistry.BLOCKS.get("fertilized_sand"))) {
-                topBlock.randomTick(topBlockState, world, pos.up(height), random);
-                break;
+            Block topBlock = world.getBlockState(pos.up(height)).getBlock();
+
+            if (topBlock == BlockRegistry.BLOCKS.get("fertilized_farmland")) continue;
+            if (topBlock == BlockRegistry.BLOCKS.get("fertilized_dirt")) continue;
+            if (topBlock == BlockRegistry.BLOCKS.get("fertilized_sand")) continue;
+
+            if (topBlock instanceof SugarCaneBlock || topBlock instanceof CactusBlock) {
+                while (true) {
+                    Block nextTopBlock = world.getBlockState(pos.up(height + 1)).getBlock();
+                    if (!(nextTopBlock instanceof SugarCaneBlock || nextTopBlock instanceof CactusBlock)) break;
+                    height++;
+                }
             }
+
+            BlockState tickBlockState = world.getBlockState(pos.up(height));
+            Block tickBlock = tickBlockState.getBlock();
+            tickBlock.randomTick(tickBlockState, world, pos.up(height), random);
+            break;
         }
     }
 

--- a/src/main/java/wraith/croptosis/block/FertilizedDirtBlock.java
+++ b/src/main/java/wraith/croptosis/block/FertilizedDirtBlock.java
@@ -2,12 +2,11 @@ package wraith.croptosis.block;
 
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
-import net.minecraft.block.CactusBlock;
-import net.minecraft.block.SugarCaneBlock;
 import net.minecraft.server.world.ServerWorld;
 import net.minecraft.state.StateManager;
 import net.minecraft.state.property.IntProperty;
 import net.minecraft.util.math.BlockPos;
+import wraith.croptosis.registry.BlockRegistry;
 
 import java.util.Random;
 
@@ -35,21 +34,14 @@ public class FertilizedDirtBlock extends Block {
     public void randomTick(BlockState state, ServerWorld world, BlockPos pos, Random random) {
         super.randomTick(state, world, pos, random);
 
-        BlockState topBlock = world.getBlockState(pos.up());
-        int height = 1;
-        while (true) {
-            BlockState nextTopBlockState = world.getBlockState(pos.up(height));
-            Block nextTopBlock = nextTopBlockState.getBlock();
-            if (!(nextTopBlock instanceof SugarCaneBlock || nextTopBlock instanceof CactusBlock)) {
-                --height;
+        for (int height = 1; height <= state.get(FertilizedDirtBlock.MAX_HEIGHT); height++) {
+            BlockState topBlockState = world.getBlockState(pos.up(height));
+            Block topBlock = topBlockState.getBlock();
+            if (!(topBlock == BlockRegistry.BLOCKS.get("fertilized_dirt") || topBlock == BlockRegistry.BLOCKS.get("fertilized_sand"))) {
+                topBlock.randomTick(topBlockState, world, pos.up(height), random);
                 break;
-            } else {
-                topBlock = nextTopBlockState;
             }
-            ++height;
         }
-        BlockPos topBlockPos = pos.up(height);
-        topBlock.getBlock().randomTick(topBlock, world, topBlockPos, random);
     }
 
 }

--- a/src/main/java/wraith/croptosis/block/FertilizedSandBlock.java
+++ b/src/main/java/wraith/croptosis/block/FertilizedSandBlock.java
@@ -5,6 +5,7 @@ import net.minecraft.server.world.ServerWorld;
 import net.minecraft.state.StateManager;
 import net.minecraft.state.property.IntProperty;
 import net.minecraft.util.math.BlockPos;
+import wraith.croptosis.registry.BlockRegistry;
 
 import java.util.Random;
 
@@ -32,21 +33,14 @@ public class FertilizedSandBlock extends SandBlock {
     public void randomTick(BlockState state, ServerWorld world, BlockPos pos, Random random) {
         super.randomTick(state, world, pos, random);
 
-        BlockState topBlock = world.getBlockState(pos.up());
-        int height = 1;
-        while (true) {
-            BlockState nextTopBlockState = world.getBlockState(pos.up(height));
-            Block nextTopBlock = nextTopBlockState.getBlock();
-            if (!(nextTopBlock instanceof SugarCaneBlock || nextTopBlock instanceof CactusBlock)) {
-                --height;
-                break;
-            } else {
-                topBlock = nextTopBlockState;
+        for (int height = 1; height <= state.get(FertilizedDirtBlock.MAX_HEIGHT); height++) {
+            BlockState topBlockState = world.getBlockState(pos.up(height));
+            Block topBlock = topBlockState.getBlock();
+            if (!(topBlock == BlockRegistry.BLOCKS.get("fertilized_dirt") || topBlock == BlockRegistry.BLOCKS.get("fertilized_sand"))) {
+                topBlock.randomTick(topBlockState, world, pos.up(height), random);
+                return;
             }
-            ++height;
         }
-        BlockPos topBlockPos = pos.up(height);
-        topBlock.getBlock().randomTick(topBlock, world, topBlockPos, random);
     }
 
 }

--- a/src/main/java/wraith/croptosis/block/FertilizedSandBlock.java
+++ b/src/main/java/wraith/croptosis/block/FertilizedSandBlock.java
@@ -34,12 +34,24 @@ public class FertilizedSandBlock extends SandBlock {
         super.randomTick(state, world, pos, random);
 
         for (int height = 1; height <= state.get(FertilizedDirtBlock.MAX_HEIGHT); height++) {
-            BlockState topBlockState = world.getBlockState(pos.up(height));
-            Block topBlock = topBlockState.getBlock();
-            if (!(topBlock == BlockRegistry.BLOCKS.get("fertilized_dirt") || topBlock == BlockRegistry.BLOCKS.get("fertilized_sand"))) {
-                topBlock.randomTick(topBlockState, world, pos.up(height), random);
-                return;
+            Block topBlock = world.getBlockState(pos.up(height)).getBlock();
+
+            if (topBlock == BlockRegistry.BLOCKS.get("fertilized_farmland")) continue;
+            if (topBlock == BlockRegistry.BLOCKS.get("fertilized_dirt")) continue;
+            if (topBlock == BlockRegistry.BLOCKS.get("fertilized_sand")) continue;
+
+            if (topBlock instanceof SugarCaneBlock || topBlock instanceof CactusBlock) {
+                while (true) {
+                    Block nextTopBlock = world.getBlockState(pos.up(height + 1)).getBlock();
+                    if (!(nextTopBlock instanceof SugarCaneBlock || nextTopBlock instanceof CactusBlock)) break;
+                    height++;
+                }
             }
+
+            BlockState tickBlockState = world.getBlockState(pos.up(height));
+            Block tickBlock = tickBlockState.getBlock();
+            tickBlock.randomTick(tickBlockState, world, pos.up(height), random);
+            break;
         }
     }
 


### PR DESCRIPTION
Fixes #2 

Refactored the loop so that it checks each block above the current block (up to MAX_HEIGHT) and randomTick()'s the first block it finds that is not a Fertilized Dirt block or a Fertilized Sand block.  The code did not previously check for MAX_HEIGHT.

Removed references to Cactus and Sugar Cane.  I theorized we didn't need to care what was sitting on top of the fertilized block (as long as it wasn't another fertilized block) and just randomly tick it.  However, I might not be familiar enough with growth mechanics for Cactus and Sugar Cane (I am researching it more).  I may submit another patch to only tick the top-most block of Cactus and Sugar Cane.

One side effect is that you can stack a mixture of Fertilized Dirt and Fertilized Sand on top of each other and still allow the extra growth factor to occur.  I was not sure if your preference is for them to be all the same block or if mixing them were okay.  

Another side effect is that if you have a non-fertilized block in the middle (like FertDirt, Dirt, FertDirt, FertDirt, Wheat), the two blocks that get randomly ticked would be the dirt block (thus likely doing nothing) and the wheat block.  It effectively means that the "extra growth factor" is only coming from two of the Fertilized Dirt blocks and not from all three.  I believe this is the correct behavior.